### PR TITLE
feature : Set a custom plugin icon from settings

### DIFF
--- a/src/custom-resolver/link-hover.ts
+++ b/src/custom-resolver/link-hover.ts
@@ -26,7 +26,7 @@ export function createLinkHoverHandler(
         if (popOver.state === PopoverState.Hidden) return;
 
         const container = popOver.hoverEl.createDiv();
-        const component = createRefRenderer(ref, app, container);
+        const component = createRefRenderer(ref, app, container, workspace.settings);
         popOver.addChild(component);
         if (component instanceof NoteRefRenderChild) await component.loadFile();
 

--- a/src/custom-resolver/ref-live.ts
+++ b/src/custom-resolver/ref-live.ts
@@ -55,7 +55,7 @@ export class RefLivePlugin implements PluginValue {
     if (!target || target.type !== "maybe-note") return;
 
     const loadComponent = (widget: InternalEmbedWidget) => {
-      const renderer = createRefRenderer(target, this.app, widget.containerEl);
+      const renderer = createRefRenderer(target, this.app, widget.containerEl, this.workspace.settings);
       if (renderer instanceof NoteRefRenderChild) renderer.loadFile();
       widget.addChild(renderer);
     };

--- a/src/custom-resolver/ref-markdown-processor.ts
+++ b/src/custom-resolver/ref-markdown-processor.ts
@@ -15,8 +15,7 @@ export function createRefMarkdownProcessor(
 
       const target = workspace.resolveRef(context.sourcePath, link);
       if (!target || target.type !== "maybe-note") return;
-
-      const renderer = createRefRenderer(target, app, el as HTMLElement);
+      const renderer = createRefRenderer(target, app, el as HTMLElement, workspace.settings);
       if (renderer instanceof NoteRefRenderChild) promises.push(renderer.loadFile());
 
       context.addChild(renderer);

--- a/src/custom-resolver/ref-render.ts
+++ b/src/custom-resolver/ref-render.ts
@@ -11,6 +11,7 @@ import {
 import { openFile } from "../utils";
 import { MaybeNoteRef, RefRange, anchorToLinkSubpath } from "../engine/ref";
 import { structuredActivityBarName } from "../icons";
+import { StructuredTreePluginSettings } from "src/settings";
 
 const MarkdownRendererConstructor = MarkdownRenderer as unknown as MarkdownRendererConstructorType;
 
@@ -42,7 +43,8 @@ export class NoteRefRenderChild extends MarkdownRenderChild {
   constructor(
     public readonly app: App,
     public readonly containerEl: HTMLElement,
-    public readonly ref: MaybeNoteRef
+    public readonly ref: MaybeNoteRef,
+    settings: StructuredTreePluginSettings
   ) {
     super(containerEl);
 
@@ -60,7 +62,7 @@ export class NoteRefRenderChild extends MarkdownRenderChild {
     this.containerEl.setText("");
 
     const icon = this.containerEl.createDiv("structured-icon");
-    setIcon(icon, structuredActivityBarName);
+    setIcon(icon, settings.pluginIcon);
 
     this.previewEl = this.containerEl.createDiv("markdown-embed-content");
 
@@ -153,14 +155,14 @@ export class NoteRefRenderChild extends MarkdownRenderChild {
 }
 
 export class UnresolvedRefRenderChild extends MarkdownRenderChild {
-  constructor(app: App, containerEl: HTMLElement, target: MaybeNoteRef) {
+  constructor(app: App, containerEl: HTMLElement, target: MaybeNoteRef, settings: StructuredTreePluginSettings) {
     super(containerEl);
 
     this.containerEl.classList.add("structured-embed", "file-embed", "mod-empty", "is-loaded");
     this.containerEl.setText("");
 
     const icon = this.containerEl.createDiv("structured-icon");
-    setIcon(icon, structuredActivityBarName);
+    setIcon(icon, settings.pluginIcon);
     const content = this.containerEl.createDiv();
 
     const { vaultName, vault, path } = target;
@@ -183,10 +185,10 @@ export class UnresolvedRefRenderChild extends MarkdownRenderChild {
   }
 }
 
-export function createRefRenderer(target: MaybeNoteRef, app: App, container: HTMLElement) {
+export function createRefRenderer(target: MaybeNoteRef, app: App, container: HTMLElement, settings: StructuredTreePluginSettings) {
   if (!target.note || !target.note.file) {
-    return new UnresolvedRefRenderChild(app, container, target);
+    return new UnresolvedRefRenderChild(app, container, target, settings);
   } else {
-    return new NoteRefRenderChild(app, container, target);
+    return new NoteRefRenderChild(app, container, target, settings);
   }
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,3 +1,5 @@
+import { SuggestModal, setIcon, getIconIds} from "obsidian";
+
 export const structuredActivityBarName = "structured-activity-bar";
 
 // Function to wrap the SVG path in an SVG element
@@ -12,3 +14,28 @@ const structuredActivityBarIconPath = `<path d="m62.094 52.941h-3.2695c-2.1445 0
 export const structuredActivityBarIcon = getStructuredActivityBarIcon(
   structuredActivityBarIconPath
 );
+
+export  class IconSuggestModal extends SuggestModal<string> {
+
+  getSuggestions(query: string): string[] | Promise<string[]> {
+    const allIcons = getIconIds();
+    if(!query) return allIcons;
+    return allIcons.filter((icon) =>
+      icon.toLowerCase().includes(query.toLowerCase())
+    )
+  }
+
+  renderSuggestion(value: string, el: HTMLElement): void {
+    setIcon(el, value);
+    el.style.width = 'fit-content';
+    el.style.height = 'fit-content';
+    el.style.display = 'flex';
+    el.style.alignItems = 'center';
+    this.resultContainerEl.style.display = 'flex';
+    this.resultContainerEl.style.flexFlow = 'row wrap';
+  }
+
+  onChooseSuggestion(item: string, evt: MouseEvent | KeyboardEvent): void {
+    
+  }
+}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,4 +1,4 @@
-import { SuggestModal, setIcon, getIconIds} from "obsidian";
+import { SuggestModal, setIcon, getIconIds, ButtonComponent} from "obsidian";
 
 export const structuredActivityBarName = "structured-activity-bar";
 
@@ -38,4 +38,19 @@ export  class IconSuggestModal extends SuggestModal<string> {
   onChooseSuggestion(item: string, evt: MouseEvent | KeyboardEvent): void {
     
   }
+}
+
+export function attachIconModal(button: ButtonComponent) {
+  const modal = new IconSuggestModal(this.app);
+  const modalEl = modal.modalEl;
+  const buttonRect = button.buttonEl.getBoundingClientRect();
+  const width = 248;
+
+  modalEl.style.width = `${248}px`;
+  modalEl.style.height = '240px';
+  modalEl.style.position = 'absolute';
+  modalEl.style.top = `${buttonRect.bottom}px`;
+  modalEl.style.left = `${buttonRect.right - width}px`;
+  modalEl.style.transform = "none";
+  modal.open();
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,4 +1,4 @@
-import { SuggestModal, setIcon, getIconIds, ButtonComponent} from "obsidian";
+import { App, SuggestModal, setIcon, getIconIds, ButtonComponent} from "obsidian";
 
 export const structuredActivityBarName = "structured-activity-bar";
 
@@ -16,6 +16,12 @@ export const structuredActivityBarIcon = getStructuredActivityBarIcon(
 );
 
 export  class IconSuggestModal extends SuggestModal<string> {
+  private onSelectCallback: (iconId: string | null) => void;
+
+  constructor (app: App, onSelect: (iconId: string | null) => void) {
+    super(app);
+    this.onSelectCallback = onSelect;
+  }
 
   getSuggestions(query: string): string[] | Promise<string[]> {
     const allIcons = getIconIds();
@@ -35,13 +41,13 @@ export  class IconSuggestModal extends SuggestModal<string> {
     this.resultContainerEl.style.flexFlow = 'row wrap';
   }
 
-  onChooseSuggestion(item: string, evt: MouseEvent | KeyboardEvent): void {
-    
+  onChooseSuggestion(iconId: string, evt: MouseEvent | KeyboardEvent): void {
+    this.onSelectCallback(iconId);
   }
 }
 
-export function attachIconModal(button: ButtonComponent) {
-  const modal = new IconSuggestModal(this.app);
+export function attachIconModal(button: ButtonComponent, onSelect: (iconId: string|null) => void) {
+  const modal = new IconSuggestModal(this.app, onSelect);
   const modalEl = modal.modalEl;
   const buttonRect = button.buttonEl.getBoundingClientRect();
   const width = 248;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Menu, Plugin, TAbstractFile, TFile, addIcon, View } from "obsidian";
+import { Menu, Plugin, TAbstractFile, TFile, addIcon, View, setIcon } from "obsidian";
 import { StructuredView, VIEW_TYPE_STRUCTURED } from "./view";
 import { activeFile, structuredVaultList } from "./store";
 import { structuredActivityBarIcon, structuredActivityBarName } from "./icons";
@@ -32,6 +32,7 @@ export default class StructuredTreePlugin extends Plugin {
   workspace: StructuredWorkspace;
   customResolver?: CustomResolver;
   customGraph?: CustomGraph;
+  ribbonElId: string = 'structured-ribbon-icon'
 
   async onload() {
     await this.loadSettings();
@@ -60,9 +61,9 @@ export default class StructuredTreePlugin extends Plugin {
 
     this.registerView(VIEW_TYPE_STRUCTURED, (leaf) => new StructuredView(leaf, this));
 
-    this.addRibbonIcon(structuredActivityBarName, "Open Structured Tree", () => {
+    this.addRibbonIcon(this.settings.pluginIcon, "Open Structured Tree", () => {
       this.activateView();
-    });
+    }).setAttr('id', this.ribbonElId);
 
     this.app.workspace.onLayoutReady(() => {
       this.onRootFolderChanged();
@@ -276,5 +277,14 @@ export default class StructuredTreePlugin extends Plugin {
     await this.saveData(this.settings);
     this.workspace.vaultList.forEach((vault) => vault.updateAcceptedExtensionsCache());
     this.app.workspace.trigger("structured-tree:settings-changed");
+  }
+
+  updateRibbonIcon() {
+    const ribbonIconEl = document.getElementById(this.ribbonElId)
+    if (!ribbonIconEl) {
+      return;
+    }
+
+    setIcon(ribbonIconEl, this.settings.pluginIcon)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,7 +216,7 @@ export default class StructuredTreePlugin extends Plugin {
 
     menu.addItem((item) => {
       item
-        .setIcon(structuredActivityBarName)
+        .setIcon(this.settings.pluginIcon)
         .setTitle("Reveal in Structured Tree")
         .onClick(() => this.revealFile(file));
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,4 +287,15 @@ export default class StructuredTreePlugin extends Plugin {
 
     setIcon(ribbonIconEl, this.settings.pluginIcon)
   }
+
+  updateViewLeafIcon() {
+    let leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_STRUCTURED)
+    if( leaves.length == 0) {
+      return;
+    }
+  
+    let leaf = leaves[0]
+    leaf.detach()
+    this.activateView()
+  }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,8 +102,14 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
       )
       .addButton(button => button
         .setButtonText('Set Icon')
-        .onClick(() => {
-          attachIconModal(button)
+        .onClick(iconId => {
+          attachIconModal(button, iconId => {
+            if(!iconId) return;
+            this.plugin.settings.pluginIcon = iconId
+            this.plugin.saveSettings().then(() => {
+              this.display();
+            })
+          })
         })
       )
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -103,7 +103,7 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
       .addButton(button => button
         .setButtonText('Set Icon')
         .onClick(() => {
-          attachIconModal()
+          attachIconModal(button)
         })
       )
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -108,6 +108,7 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
             this.plugin.settings.pluginIcon = iconId
             this.plugin.saveSettings().then(() => {
               this.plugin.updateRibbonIcon()
+              this.plugin.updateViewLeafIcon()
               this.display();
               this.updateIconSetButton(button)
             })
@@ -540,6 +541,7 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
         this.plugin.settings.pluginIcon = DEFAULT_SETTINGS.pluginIcon
         this.plugin.saveSettings().then(() => {
           this.plugin.updateRibbonIcon();
+          this.plugin.updateViewLeafIcon()
           this.display()
         })
       })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import StructuredTreePlugin from "./main";
 import { VaultConfig } from "./engine/structuredVault";
 import { AddVaultModal } from "./modal/folderSuggester";
 import { ConfirmationModal } from "./modal/confirmationModal";
-import { structuredActivityBarName } from "./icons";
+import { attachIconModal, structuredActivityBarName } from "./icons";
 
 export interface StructuredTreePluginSettings {
   vaultPath?: string;
@@ -102,6 +102,9 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
       )
       .addButton(button => button
         .setButtonText('Set Icon')
+        .onClick(() => {
+          attachIconModal()
+        })
       )
 
     new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import StructuredTreePlugin from "./main";
 import { VaultConfig } from "./engine/structuredVault";
 import { AddVaultModal } from "./modal/folderSuggester";
 import { ConfirmationModal } from "./modal/confirmationModal";
+import { structuredActivityBarName } from "./icons";
 
 export interface StructuredTreePluginSettings {
   vaultPath?: string;
@@ -26,6 +27,7 @@ export interface StructuredTreePluginSettings {
   fuzzySearchFileNameWeight: number;
   fuzzySearchThreshold: number;
   excludedPaths: string[];
+  pluginIcon: string
 }
 
 export const DEFAULT_SETTINGS: StructuredTreePluginSettings = {
@@ -54,6 +56,7 @@ export const DEFAULT_SETTINGS: StructuredTreePluginSettings = {
   fuzzySearchFileNameWeight: 0.6,
   fuzzySearchThreshold: 0.2,
   excludedPaths: [],
+  pluginIcon: structuredActivityBarName
 };
 
 export const DENDRON_SETTINGS: Partial<StructuredTreePluginSettings> = {
@@ -88,6 +91,18 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
     const { containerEl } = this;
 
     containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Plugin Icon')
+      .setDesc('Choose an icon for the plugin.')
+      .addExtraButton(button => button
+        .setDisabled(false)
+        .setIcon(this.plugin.settings.pluginIcon)
+        .setTooltip(this.plugin.settings.pluginIcon)
+      )
+      .addButton(button => button
+        .setButtonText('Set Icon')
+      )
 
     new Setting(containerEl)
       .setName("Auto Reveal")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
+import { App, ButtonComponent, Notice, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
 import StructuredTreePlugin from "./main";
 import { VaultConfig } from "./engine/structuredVault";
 import { AddVaultModal } from "./modal/folderSuggester";
@@ -108,9 +108,11 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
             this.plugin.settings.pluginIcon = iconId
             this.plugin.saveSettings().then(() => {
               this.display();
+              this.updateIconSetButton(button)
             })
           })
         })
+        .then(() => this.updateIconSetButton(button))
       )
 
     new Setting(containerEl)
@@ -524,5 +526,18 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
     this.plugin.onRootFolderChanged();
     this.plugin.configureCustomResolver();
     this.plugin.configureCustomGraph();
+  }
+  
+  updateIconSetButton(button: ButtonComponent) {
+    if(this.plugin.settings.pluginIcon == DEFAULT_SETTINGS.pluginIcon) {
+      return;
+    }
+  
+    button
+      .setButtonText('Reset Icon')
+      .onClick(() => {
+        this.plugin.settings.pluginIcon = DEFAULT_SETTINGS.pluginIcon
+        this.plugin.saveSettings().then(() => this.display())
+      })
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -107,6 +107,7 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
             if(!iconId) return;
             this.plugin.settings.pluginIcon = iconId
             this.plugin.saveSettings().then(() => {
+              this.plugin.updateRibbonIcon()
               this.display();
               this.updateIconSetButton(button)
             })
@@ -537,7 +538,10 @@ export class StructuredTreeSettingTab extends PluginSettingTab {
       .setButtonText('Reset Icon')
       .onClick(() => {
         this.plugin.settings.pluginIcon = DEFAULT_SETTINGS.pluginIcon
-        this.plugin.saveSettings().then(() => this.display())
+        this.plugin.saveSettings().then(() => {
+          this.plugin.updateRibbonIcon();
+          this.display()
+        })
       })
   }
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -16,6 +16,7 @@ export class StructuredView extends ItemView {
     private plugin: StructuredTreePlugin
   ) {
     super(leaf);
+    this.icon = this.plugin.settings.pluginIcon
   }
 
   getViewType() {


### PR DESCRIPTION
For now, only the Lucide icons made available through the Obsidian API are suggested in the modal.
I add auto-update for the ribbon and the leaf view icon.
I also modified the icon used by the custom resolver feature (a reload of the page is necessary to apply the new icon).